### PR TITLE
Implement dragon booking cancelation - Action

### DIFF
--- a/src/components/Dragons.jsx
+++ b/src/components/Dragons.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import '../Styles/Dragons.css';
-import { fetchDragons, reserveDragon } from '../redux/dragons/dragonsSlice';
+import { fetchDragons, reserveDragon, cancelDragon } from '../redux/dragons/dragonsSlice';
 
 function Dragons() {
   const dispatch = useDispatch();
@@ -29,10 +29,23 @@ function Dragons() {
               {/* <span className="reserved-span">Reserved</span> */}
               {dragon.description}
             </p>
-            <button type="button" className="reserve-btn" onClick={() => dispatch(reserveDragon(dragon.id))}>
-              Reserve dragon
-              {/* {isDragonReserved(dragon.id) ? 'Reserved' : 'Reserve dragon'} */}
-            </button>
+            {!dragon.reserved ? (
+              <button
+                type="button"
+                className="reserve-btn"
+                onClick={() => dispatch(reserveDragon(dragon.id))}
+              >
+                Reserve Dragon
+              </button>
+            ) : (
+              <button
+                type="button"
+                className="reserve-btn"
+                onClick={() => dispatch(cancelDragon(dragon.id))}
+              >
+                Reserve Dragon
+              </button>
+            )}
           </div>
         </div>
       ))}

--- a/src/redux/dragons/dragonsSlice.js
+++ b/src/redux/dragons/dragonsSlice.js
@@ -21,6 +21,7 @@ export const fetchDragons = createAsyncThunk('dragon/fetchDragons', async () => 
 });
 
 export const reserveDragon = createAsyncThunk('dragon/reserveDragon', (id) => id);
+export const cancelDragon = createAsyncThunk('dragon/cancelDragon', (id) => id);
 
 const dragonsSlice = createSlice({
   name: 'dragon',
@@ -44,6 +45,17 @@ const dragonsSlice = createSlice({
       const newState = state.dragonsData.map((dragon) => {
         if (dragon.id === id) {
           return { ...dragon, reserved: true };
+        }
+        return dragon;
+      });
+      state.dragonsData = newState;
+    },
+    [cancelDragon.fulfilled]: (state, action) => {
+      state.isLoading = false;
+      const id = action.payload;
+      const newState = state.dragonsData.map((dragon) => {
+        if (dragon.id === id) {
+          return { ...dragon, reserved: false };
         }
         return dragon;
       });


### PR DESCRIPTION
# In this milestone:

- Follow the same logic as with the "Reserve dragon" - but you need to set the `reserved` key to `false`. 
- Dispatch these actions upon click on the corresponding buttons.
