### PR TITLE
Switch badges for Rockets - Conditional components

### DIFF
--- a/src/components/Rockets.jsx
+++ b/src/components/Rockets.jsx
@@ -21,7 +21,9 @@ function Rockets() {
           <div className="rocket-data">
             <h2 className="rocket-title">{rocket.name}</h2>
             <p className="rocket-info">
-              {/* <span className="reserved-span">Reserved</span> */}
+              {rocket.reserved && (
+                <span className="reserved-span">Reserved</span>
+              )}
               {rocket.description}
             </p>
             {!rocket.reserved ? (
@@ -38,7 +40,7 @@ function Rockets() {
                 className="reserve-btn"
                 onClick={() => dispatch(cancelRocket(rocket.id))}
               >
-                Reserve Rocket
+                Cancel Reservation
               </button>
             )}
           </div>


### PR DESCRIPTION
Rockets that have already been reserved should show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket" (as per design)

Use the React conditional rendering syntax:
```javascript
{rocket.reserved && ( 
    // render Cancel Rocket button
)}
```